### PR TITLE
fix collisions when applying devicetree diff (e.g. i2s0/audio0 and i2c0/audio0)

### DIFF
--- a/dt/ddt.py
+++ b/dt/ddt.py
@@ -116,12 +116,12 @@ class DTNode:
 
         return res
 
-    def iterate(self, callback, depth: int = 0):
-        if not callback(self, depth):
+    def iterate(self, callback, depth: int = 0, path_so_far: list = []):
+        if not callback(self, depth, path_so_far + [self.name]):
             return
 
         for child in self.children:
-            child.iterate(callback, depth + 1)    
+            child.iterate(callback, depth + 1, path_so_far + [self.name])
 
         return True
 
@@ -129,19 +129,15 @@ class DTNode:
         found = None
         tokens = path.split("/")
 
-        def cb(node: DTNode, depth: int):
+        def cb(node: DTNode, depth: int, path_so_far: list):
             nonlocal found, tokens
 
             if found:
                 return False
 
-            if depth == len(tokens):
+            if path_so_far == tokens:
+                found = node
                 return False
-
-            if node.name == tokens[depth]:
-                if depth == len(tokens) - 1:
-                    found = node
-                    return False
 
             return True
 
@@ -171,7 +167,7 @@ def do_diff(args):
     path_nodes = list()
     prev_depth = -1
 
-    def cb(node: DTNode, depth: int):
+    def cb(node: DTNode, depth: int, path_so_far: list):
         nonlocal prev_depth
 
         for _ in range(prev_depth - depth + 1):


### PR DESCRIPTION
Hi,

We've been using your `ddt.py` to play with iOS 7 on iPad 1 and ran into an edge case where [this](https://github.com/amy-and-nicole/ipad-1-ios-7/blob/main/resources/device%20tree.diff#L110) line was applied to `i2c0/audio0` instead of `i2s0/audio0` since only the depth and final node name are checked.

Inexperienced with both Python and iOS so there may well be a better approach, but figured I should bring it to your attention anyways.

Thanks!